### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ func init() {
 	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
 			PartitionID:   "aws",
-			URL:           "http://localstack_main:4566",
+			URL:           "http://localstack-main:4566",
 			SigningRegion: region,
 		}, nil
 	})


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
