### PR TITLE
fix: update LocalStack license requirement and standardize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install CDK
         run: |
@@ -40,7 +40,7 @@ jobs:
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           DNS_ADDRESS: 0
         run: |
           make test
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload the Diagnostic Report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diagnose.json.gz
           path: ./diagnose.json.gz

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-.PHONY: install init build build_docker test deploy start-ls stop-ls
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+.PHONY: install init build build_docker test deploy start-ls stop-ls start stop ready logs
 
 .EXPORT_ALL_VARIABLES:
 GOPROXY = direct
 NETWORK_NAME="localstack-shared-net"
 
-install: 
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$//' | sed -e 's/##//'
+
+install: 	## Install dependencies
 	@which localstack || pip install localstack
 	@which awslocal || pip install awscli-local
 
@@ -20,9 +28,24 @@ deploy: build_docker
 	cdklocal bootstrap;\
 	cdklocal deploy ---require-approval never
 
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
 start-ls:
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
 	-docker network create $(NETWORK_NAME) 2> /dev/null;
-	LAMBDA_DOCKER_NETWORK=$(NETWORK_NAME) DOCKER_FLAGS="--network $(NETWORK_NAME)" DEBUG=1 localstack start -d
+	LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) LAMBDA_DOCKER_NETWORK=$(NETWORK_NAME) DOCKER_FLAGS="--network $(NETWORK_NAME)" DEBUG=1 localstack start -d
 
 stop-ls:
 	localstack stop

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export AWS_SECRET_ACCESS_KEY ?= test
 export AWS_DEFAULT_REGION=us-east-1
 SHELL := /bin/bash
 
-.PHONY: install init build build_docker test deploy start-ls stop-ls start stop ready logs
+.PHONY: install init build build_docker test deploy start stop ready logs
 
 .EXPORT_ALL_VARIABLES:
 GOPROXY = direct
@@ -28,10 +28,6 @@ deploy: build_docker
 	cdklocal bootstrap;\
 	cdklocal deploy ---require-approval never
 
-start:		## Start LocalStack
-	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
-
 stop:		## Stop LocalStack
 	@localstack stop
 
@@ -42,18 +38,15 @@ ready:		## Wait until LocalStack is ready
 logs:		## Save the logs in a separate file
 	@localstack logs > logs.txt
 
-start-ls:
+start:
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
 	-docker network create $(NETWORK_NAME) 2> /dev/null;
 	LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) LAMBDA_DOCKER_NETWORK=$(NETWORK_NAME) DOCKER_FLAGS="--network $(NETWORK_NAME)" DEBUG=1 localstack start -d
 
-stop-ls:
-	localstack stop
-
-run: start-ls init deploy
+run: start init deploy
 	./run.sh
-	make stop-ls
+	make stop
 
-test: install start-ls init deploy
+test: install start init deploy
 	./run.sh;./test.sh;exit_code=`echo $$?`;\
-	make stop-ls; exit $$exit_code
+	make stop; exit $$exit_code

--- a/README.md
+++ b/README.md
@@ -32,10 +32,21 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- LocalStack Pro with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [Cloud Development Kit](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) installed.
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
 - [Node.js](https://nodejs.org/en/download)
+
+## Start LocalStack
+
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+
+```bash
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
+```
 
 ## Instructions
 
@@ -47,7 +58,7 @@ Here are instructions to deploy and test it manually step-by-step.
 Before starting the LocalStack container, configure the following environment variables which act as configurations for the LocalStack container:
 
 ```bash
-export LOCALSTACK_API_KEY=<your_api_key>
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 export SQS_QUEUE="sqs-fargate-queue"
 export NETWORK_NAME="localstack-shared-net"
 ```

--- a/README.md
+++ b/README.md
@@ -38,16 +38,6 @@ The following diagram shows the architecture that this sample application builds
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
 - [Node.js](https://nodejs.org/en/download)
 
-## Start LocalStack
-
-Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
-
-```bash
-export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-make start
-make ready
-```
-
 ## Instructions
 
 You can build and deploy the sample application on LocalStack by running `make run`.
@@ -58,7 +48,6 @@ Here are instructions to deploy and test it manually step-by-step.
 Before starting the LocalStack container, configure the following environment variables which act as configurations for the LocalStack container:
 
 ```bash
-export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 export SQS_QUEUE="sqs-fargate-queue"
 export NETWORK_NAME="localstack-shared-net"
 ```
@@ -73,9 +62,10 @@ docker network create $NETWORK_NAME
 
 This network is required for the Fargate ECS container to be able to [use LocalStack services from the running Docker container](https://docs.localstack.cloud/references/network-troubleshooting/endpoint-url/#from-your-container).
 
-Run the following command to start the LocalStack container:
+Run the following command to start the LocalStack container with your `LOCALSTACK_AUTH_TOKEN`:
 
 ```bash
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 LAMBDA_DOCKER_NETWORK=$NETWORK_NAME DOCKER_FLAGS="--network $NETWORK_NAME" DEBUG=1 localstack start -d
 ```
 


### PR DESCRIPTION
## Summary

- Add auth guard and standard targets to Makefile; replace LOCALSTACK_API_KEY with LOCALSTACK_AUTH_TOKEN
- Add license bullet and start section to README; update LOCALSTACK_API_KEY in instructions
- Upgrade checkout@v3 to v4, setup-node@v3 to v4, Node 18 to 22, upload-artifact@v3 to v4 in CI workflow
