### PR TITLE
fix: use LocalStack-injected AWS_ENDPOINT_URL in the Fargate worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ docker network create $NETWORK_NAME
 
 This network is required for the Fargate ECS container to be able to [use LocalStack services from the running Docker container](https://docs.localstack.cloud/references/network-troubleshooting/endpoint-url/#from-your-container).
 
+The Go worker reads `AWS_ENDPOINT_URL` (injected by LocalStack into ECS tasks) so it can call SQS and DynamoDB without hardcoding a container hostname. On real AWS those variables are unset and the SDK uses the default regional endpoints.
+
 Run the following command to start the LocalStack container with your `LOCALSTACK_AUTH_TOKEN`:
 
 ```bash

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,22 +33,36 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
 	var err error
+	loadOpts := []func(*config.LoadOptions) error{}
 
-	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		return aws.Endpoint{
-			PartitionID:   "aws",
-			URL:           "http://localstack-main:4566",
-			SigningRegion: region,
-		}, nil
-	})
+	// LocalStack injects AWS_ENDPOINT_URL (and LOCALSTACK_HOSTNAME) into ECS tasks.
+	// On real AWS these are unset, so the SDK uses the default regional endpoints.
+	if endpoint := localStackEndpoint(); endpoint != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           endpoint,
+				SigningRegion: region,
+			}, nil
+		})
+		loadOpts = append(loadOpts, config.WithEndpointResolverWithOptions(customResolver))
+	}
 
-	cfg, err = config.LoadDefaultConfig(context.Background(),
-		config.WithEndpointResolverWithOptions(customResolver),
-	)
+	cfg, err = config.LoadDefaultConfig(context.Background(), loadOpts...)
 	if err != nil {
 		log.Fatalf("error loading config %v", err)
 	}
 
+}
+
+func localStackEndpoint() string {
+	if endpoint := os.Getenv("AWS_ENDPOINT_URL"); endpoint != "" {
+		return endpoint
+	}
+	if host := os.Getenv("LOCALSTACK_HOSTNAME"); host != "" {
+		return fmt.Sprintf("http://%s:4566", host)
+	}
+	return ""
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- Stop hardcoding `http://localstack-main:4566` in the Go Fargate worker. That hostname does not resolve when the emulator container is named something else (for example `localstack-aws` with `lstk`), so ECS tasks crash-loop on `lookup localstack-main: no such host` and never write to DynamoDB.
- Read `AWS_ENDPOINT_URL` (and `LOCALSTACK_HOSTNAME` as a fallback) that LocalStack already injects into ECS tasks. On real AWS those variables are unset, so the SDK keeps using default regional endpoints.
