### PR TITLE
Migrate from the localstack CLI to lstk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
 
       - name: Install CDK
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g @localstack/lstk aws-cdk
+          cdk --version
+
+      - name: Configure the AWS profile
+        run: lstk setup aws
 
       - name: Install dependencies
         run: |
@@ -41,7 +44,7 @@ jobs:
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          DNS_ADDRESS: 0
+          LOCALSTACK_DNS_ADDRESS: 0
         run: |
           make test
 

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,16 @@ export AWS_SECRET_ACCESS_KEY ?= test
 export AWS_DEFAULT_REGION=us-east-1
 SHELL := /bin/bash
 
-.PHONY: install init build build_docker test deploy start stop ready logs
+.PHONY: install init build build_docker test deploy start stop logs
 
 .EXPORT_ALL_VARIABLES:
 GOPROXY = direct
-NETWORK_NAME="localstack-shared-net"
 
 usage:		## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$//' | sed -e 's/##//'
 
 install: 	## Install dependencies
-	@which localstack || pip install localstack
-	@which awslocal || pip install awscli-local
+	@which lstk || npm install -g @localstack/lstk aws-cdk
 
 init:
 	cd cdk;\
@@ -25,23 +23,18 @@ build_docker:
 
 deploy: build_docker
 	cd cdk;\
-	cdklocal bootstrap;\
-	cdklocal deploy ---require-approval never
+	lstk cdk bootstrap;\
+	lstk cdk deploy ---require-approval never
 
 stop:		## Stop LocalStack
-	@localstack stop
-
-ready:		## Wait until LocalStack is ready
-	@echo Waiting on the LocalStack container...
-	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+	@lstk stop --non-interactive
 
 logs:		## Save the logs in a separate file
-	@localstack logs > logs.txt
+	@lstk logs --non-interactive > logs.txt
 
 start:
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	-docker network create $(NETWORK_NAME) 2> /dev/null;
-	LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) LAMBDA_DOCKER_NETWORK=$(NETWORK_NAME) DOCKER_FLAGS="--network $(NETWORK_NAME)" DEBUG=1 localstack start -d
+	LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) LOCALSTACK_DEBUG=1 lstk start
 
 run: start init deploy
 	./run.sh

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [Cloud Development Kit](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) installed.
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/aws/getting-started/auth-token/) to activate LocalStack.
+- [`lstk` CLI](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/), installed via `npm install -g @localstack/lstk` or `brew install localstack/tap/lstk`.
+- [Cloud Development Kit](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/), deployed via the `lstk cdk` proxy.
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/), required by `lstk aws`.
 - [Node.js](https://nodejs.org/en/download)
 
 ## Instructions
@@ -45,22 +45,11 @@ Here are instructions to deploy and test it manually step-by-step.
 
 ### Running the LocalStack container
 
-Before starting the LocalStack container, configure the following environment variables which act as configurations for the LocalStack container:
+Before starting the LocalStack container, configure the following environment variable for the SQS queue name:
 
 ```bash
 export SQS_QUEUE="sqs-fargate-queue"
-export NETWORK_NAME="localstack-shared-net"
 ```
-
-The `SQS_QUEUE` and `NETWORK_NAME` can be any name that confirms to the naming conventions of SQS and Docker networks respectively.
-
-To create a Docker network, run the following command:
-
-```bash
-docker network create $NETWORK_NAME
-```
-
-This network is required for the Fargate ECS container to be able to [use LocalStack services from the running Docker container](https://docs.localstack.cloud/references/network-troubleshooting/endpoint-url/#from-your-container).
 
 The Go worker reads `AWS_ENDPOINT_URL` (injected by LocalStack into ECS tasks) so it can call SQS and DynamoDB without hardcoding a container hostname. On real AWS those variables are unset and the SDK uses the default regional endpoints.
 
@@ -68,11 +57,10 @@ Run the following command to start the LocalStack container with your `LOCALSTAC
 
 ```bash
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-LAMBDA_DOCKER_NETWORK=$NETWORK_NAME DOCKER_FLAGS="--network $NETWORK_NAME" DEBUG=1 localstack start -d
+LOCALSTACK_DEBUG=1 lstk start
 ```
 
-This starts LocalStack in detached mode with the necessary configurations.
-> If you prefer to be able to follow the debug output while deploying this sample, omit the `-d` flag, then open a new terminal window and navigate to the same location as before.
+`lstk` waits until the container is ready before returning. ECS/Fargate tasks automatically join the same Docker network as the LocalStack container, so no manual Docker network setup is required.
 
 ### Build the infrastructure
 
@@ -96,8 +84,8 @@ This will navigate into the correct folder and install all necessary packages
 To deploy the sample application, we will use CDK to bootstrap the environment and deploy the infrastructure. Run the following commands:
 
 ```bash
-cdklocal bootstrap
-cdklocal deploy
+lstk cdk bootstrap
+lstk cdk deploy
 ```
 
 > While deploying the infrastructure, CDK will ask your permission — If you would rather skip the approval process, you can add the `--require-approval never` flag to the deploy command. 
@@ -107,8 +95,8 @@ cdklocal deploy
 To assert that the SQS queue and the DynamoDB have been created, run the following commands:
 
 ```bash
-awslocal sqs list-queues
-awslocal dynamodb list-tables
+lstk aws sqs list-queues
+lstk aws dynamodb list-tables
 ```
 
 You should see output similar to the following:
@@ -128,7 +116,7 @@ You should see output similar to the following:
 Next, send a message to the SQS queue. Run the following command:
 
 ```bash
-awslocal sqs send-message --queue $SQS_QUEUE --message-body '{"message": "hello world"}'
+lstk aws sqs send-message --queue $SQS_QUEUE --message-body '{"message": "hello world"}'
 ```
 
 This sends a `hello world` message to the SQS queue, which is then processed by the Fargate container. You can wait for a couple of seconds for the container to finish its task.
@@ -136,7 +124,7 @@ This sends a `hello world` message to the SQS queue, which is then processed by 
 To check if the message has been written to the DynamoDB table, run the following command:
 
 ```bash
-awslocal dynamodb scan --table-name sqs-fargate-ddb-table
+lstk aws dynamodb scan --table-name sqs-fargate-ddb-table
 ```
 
 You should see an answer similar to the following when executing the given command:

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -18,7 +18,7 @@
         "@types/jest": "^27.5.2",
         "@types/node": "10.17.27",
         "@types/prettier": "2.6.0",
-        "aws-cdk": "^2.35.0",
+        "aws-cdk": "2.1133.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.9.1",
@@ -1225,18 +1225,15 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.35.0.tgz",
-      "integrity": "sha512-H8S/tEfnqeHq5aqKHXhZjSm3ck472Nwnw6CJYkzHg5tsV6KB5EludP18SYb1h9pu8ZGWmBQ8vJ82yK9XXxFQvw==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -5464,13 +5461,10 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.35.0.tgz",
-      "integrity": "sha512-H8S/tEfnqeHq5aqKHXhZjSm3ck472Nwnw6CJYkzHg5tsV6KB5EludP18SYb1h9pu8ZGWmBQ8vJ82yK9XXxFQvw==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2"
-      }
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
+      "dev": true
     },
     "aws-cdk-lib": {
       "version": "2.35.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -14,7 +14,7 @@
     "@types/jest": "^27.5.2",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
-    "aws-cdk": "^2.35.0",
+    "aws-cdk": "2.1133.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.9.1",

--- a/run.sh
+++ b/run.sh
@@ -3,14 +3,14 @@ SQS_QUEUE="sqs-fargate-queue"
 NETWORK_NAME="localstack-shared-net"
 
 echo "List queues to check if sqs queue was created"
-awslocal sqs list-queues
+lstk aws sqs list-queues
 echo "List tables to check if dynmodb table was created"
-awslocal dynamodb list-tables
+lstk aws dynamodb list-tables
 
 echo "Send message to the sqs queue that should be stored in the db"
-awslocal sqs send-message --queue $SQS_QUEUE --message-body '{"message": "hello world"}'
+lstk aws sqs send-message --queue $SQS_QUEUE --message-body '{"message": "hello world"}'
 
 echo "Giving the container time to write the message, then check if the fargate container successfully wrote the sqs message into the dynamodb table"
 sleep 3
-awslocal dynamodb scan --table-name sqs-fargate-ddb-table
+lstk aws dynamodb scan --table-name sqs-fargate-ddb-table
 

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,9 @@ expected_db="sqs-fargate-ddb-table"
 source assert.sh/assert.sh
 
 echo "Running tests for fargate-ddb-cdk-go sample..."
-sqs_queue=$(awslocal sqs list-queues | jq -r .QueueUrls[0])
-db_table=$(awslocal dynamodb list-tables | jq -r .TableNames[0])
-ddb_item=$(awslocal dynamodb scan --table-name sqs-fargate-ddb-table | jq -r .Items[0].message.S)
+sqs_queue=$(lstk aws sqs list-queues | jq -r .QueueUrls[0])
+db_table=$(lstk aws dynamodb list-tables | jq -r .TableNames[0])
+ddb_item=$(lstk aws dynamodb scan --table-name sqs-fargate-ddb-table | jq -r .Items[0].message.S)
 
 assert_eq "$sqs_queue" "$expected_queue_url" "Queue urls do not match!"
 assert_eq "$db_table" "$expected_db" "Database tables do not match!"


### PR DESCRIPTION
## Summary
- Replace `localstack`/`awslocal`/`cdklocal` invocations with `lstk` across the Makefile, README, scripts, and CI workflow.
- Drop the manual Docker network setup (`docker network create` + `LAMBDA_DOCKER_NETWORK`/`DOCKER_FLAGS`) — ECS tasks join the LocalStack container's network automatically.
- Bump the `aws-cdk` CLI pin 2.35.0 → 2.1133.0 (`lstk` requires ≥ 2.177.0); `aws-cdk-lib` unchanged.

## Testing
- CI workflow run on this branch.

Part of DEVX-1056